### PR TITLE
Fix modularity computation error.

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -59,6 +59,7 @@ def instance2graph(path: str, compute_features: bool = False):
         lhs_coefs = lhs[np.where(nonzeros)]
         var_degree, cons_degree = nonzeros.sum(axis=0), nonzeros.sum(axis=1)
 
+        edge_indices[1] += edge_indices[0].max() + 1
         pyg_graph = Data(
             x_s = constraint_features,
             x_t = variable_features,


### PR DESCRIPTION
I am trying to fix a bug in your code that will influence the correctness of graph modularity computation. 

Specifically, the bug is in the function `instance2graph()` in `src/utils.py`.  `edge_indices` acquired by `ecole` records the constraint and variable node indices. However, both constraint nodes and variable nodes are indexed from 0, and in the function `to_networkx()`, the constraint node and variable node with the same index are considered as the same node. This will lead to a wrong converted `nx_graph`, and incorrect graph modularity.

To fix the bug, I indexed the variable nodes from `max(constraint_node_index)+1`.

Thank you for your time and looking forward to your feedback!